### PR TITLE
Session/11 isolate

### DIFF
--- a/lib/components/weather_information.dart
+++ b/lib/components/weather_information.dart
@@ -17,23 +17,40 @@ class WeatherInformation extends ConsumerWidget {
       weatherPageViewModelProvider,
       (previous, next) async {
         await next.maybeWhen(
-          error: (error, _) async => showDialog<void>(
+          error: (error, _) async {
+            Navigator.pop(context);
+            await showDialog<void>(
+              context: context,
+              barrierDismissible: false, // user must tap button!
+              builder: (context) {
+                return AlertDialog(
+                  title: Text(error.toString()),
+                  actions: <Widget>[
+                    TextButton(
+                      child: const Text('OK'),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+          loading: () => showDialog<void>(
+            barrierDismissible: false,
             context: context,
-            barrierDismissible: false, // user must tap button!
             builder: (context) {
-              return AlertDialog(
-                title: Text(error.toString()),
-                actions: <Widget>[
-                  TextButton(
-                    child: const Text('OK'),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                ],
+              return const Center(
+                child: CircularProgressIndicator(),
               );
             },
           ),
+          data: (data){
+            if (data != null) {
+              Navigator.pop(context);
+            }
+          },
           orElse: () {},
         );
       },

--- a/lib/weather/weather_data_source.dart
+++ b/lib/weather/weather_data_source.dart
@@ -21,7 +21,7 @@ class WeatherDataSource {
       SimpleLogger()
           .info('Getting weather data from Yumemi Weather Service...');
       final weatherData =
-          _yumemiWeatherService.fetchWeather(payload);
+          _yumemiWeatherService.syncFetchWeather(payload);
       SimpleLogger()
           .info('Complete to get weather data from Yumemi Weather Service!');
       return weatherData;

--- a/lib/weather/weather_data_source.dart
+++ b/lib/weather/weather_data_source.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_training/exceptions/yumemi_weather_exception.dart';
 import 'package:flutter_training/weather/yumemi_weather_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -16,12 +17,12 @@ class WeatherDataSource {
   WeatherDataSource(this._yumemiWeatherService);
   final YumemiWeather _yumemiWeatherService;
 
-  String fetchWeather(String payload) {
+  Future<String> fetchWeather(String payload) async {
     try {
       SimpleLogger()
           .info('Getting weather data from Yumemi Weather Service...');
       final weatherData =
-          _yumemiWeatherService.syncFetchWeather(payload);
+          await compute(_yumemiWeatherService.syncFetchWeather, payload);
       SimpleLogger()
           .info('Complete to get weather data from Yumemi Weather Service!');
       return weatherData;

--- a/lib/weather/weather_page_view_model.dart
+++ b/lib/weather/weather_page_view_model.dart
@@ -14,6 +14,7 @@ class WeatherPageViewModel extends _$WeatherPageViewModel {
 
   Future<void> fetchWeather(WeatherDataRequest weatherDataRequest) async {
     final weatherRepository = ref.read(weatherRepositoryProvider);
+    state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
       return weatherRepository.fetchWeather(weatherDataRequest);
     });

--- a/lib/weather/weather_page_view_model.dart
+++ b/lib/weather/weather_page_view_model.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter_training/weather/weather_data.dart';
 import 'package:flutter_training/weather/weather_data_request.dart';
 import 'package:flutter_training/weather/weather_repository.dart';
@@ -17,12 +14,7 @@ class WeatherPageViewModel extends _$WeatherPageViewModel {
     final weatherRepository = ref.read(weatherRepositoryProvider);
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
-      /// テスト時はcomputeは使えない
-      if (Platform.environment.containsKey('FLUTTER_TEST')) {
-        await Future.delayed(const Duration(milliseconds: 200), () {});
-        return weatherRepository.fetchWeather(weatherDataRequest);
-      }
-      return compute(weatherRepository.fetchWeather, weatherDataRequest);
+      return weatherRepository.fetchWeather(weatherDataRequest);
     });
   }
 }

--- a/lib/weather/weather_page_view_model.dart
+++ b/lib/weather/weather_page_view_model.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_training/weather/weather_data.dart';
 import 'package:flutter_training/weather/weather_data_request.dart';
@@ -15,6 +17,11 @@ class WeatherPageViewModel extends _$WeatherPageViewModel {
     final weatherRepository = ref.read(weatherRepositoryProvider);
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
+      /// テスト時はcomputeは使えない
+      if (Platform.environment.containsKey('FLUTTER_TEST')) {
+        await Future.delayed(const Duration(milliseconds: 200), () {});
+        return weatherRepository.fetchWeather(weatherDataRequest);
+      }
       return compute(weatherRepository.fetchWeather, weatherDataRequest);
     });
   }

--- a/lib/weather/weather_page_view_model.dart
+++ b/lib/weather/weather_page_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_training/weather/weather_data.dart';
 import 'package:flutter_training/weather/weather_data_request.dart';
 import 'package:flutter_training/weather/weather_repository.dart';
@@ -8,15 +9,13 @@ part 'weather_page_view_model.g.dart';
 @riverpod
 class WeatherPageViewModel extends _$WeatherPageViewModel {
   @override
-  Future<WeatherData?> build() async {
-    return null;
-  }
+  Future<WeatherData?> build() async => null;
 
   Future<void> fetchWeather(WeatherDataRequest weatherDataRequest) async {
     final weatherRepository = ref.read(weatherRepositoryProvider);
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
-      return weatherRepository.fetchWeather(weatherDataRequest);
+      return compute(weatherRepository.fetchWeather, weatherDataRequest);
     });
   }
 }

--- a/lib/weather/weather_repository.dart
+++ b/lib/weather/weather_repository.dart
@@ -19,11 +19,14 @@ class WeatherRepository {
   WeatherRepository(this._weatherDataSource);
   final WeatherDataSource _weatherDataSource;
 
-  WeatherData fetchWeather(WeatherDataRequest weatherDataRequest) {
+  Future<WeatherData> fetchWeather(
+    WeatherDataRequest weatherDataRequest,
+  ) async {
     final payload = json.encode(weatherDataRequest.toJson());
     final weatherString = _weatherDataSource.fetchWeather(payload);
     try {
-      final weatherJson = json.decode(weatherString) as Map<String, dynamic>;
+      final weatherJson =
+          json.decode(await weatherString) as Map<String, dynamic>;
       final weatherData = WeatherData.fromJson(weatherJson);
       return weatherData;
     } on CheckedFromJsonException catch (_) {

--- a/test/weather/weather_data_source_test.dart
+++ b/test/weather/weather_data_source_test.dart
@@ -11,7 +11,7 @@ import 'package:yumemi_weather/yumemi_weather.dart';
 
 import 'weather_data_source_test.mocks.dart';
 
-(MockYumemiWeather, WeatherDataSource) setup() {
+(MockYumemiWeather, WeatherDataSource) providerSetup() {
   final yumemiWeatherService = MockYumemiWeather();
   final container = ProviderContainer(
     overrides: [
@@ -35,7 +35,7 @@ void main() {
   group('weatherDataSourceの正常系テスト', () {
     test('When YumemiWeatherService returns sunny.', () async {
       // Arrange
-      final (yumemiWeatherService, weatherDataSource) = setup();
+      final (yumemiWeatherService, weatherDataSource) = providerSetup();
 
       final response = json.encode(
         {
@@ -55,7 +55,7 @@ void main() {
     });
     test('When YumemiWeatherService returns cloudy.', () async {
       // Arrange
-      final (yumemiWeatherService, weatherDataSource) = setup();
+      final (yumemiWeatherService, weatherDataSource) = providerSetup();
 
       final response = json.encode(
         {
@@ -75,7 +75,7 @@ void main() {
     });
     test('When YumemiWeatherService returns rainy.', () async {
       // Arrange
-      final (yumemiWeatherService, weatherDataSource) = setup();
+      final (yumemiWeatherService, weatherDataSource) = providerSetup();
 
       final response = json.encode(
         {
@@ -101,7 +101,7 @@ void main() {
         'with message of "Input parameters are wrong." '
         'when YumemiWeatherError.invalidParameter is thrown.', () {
       // Arrange
-      final (yumemiWeatherService, weatherDataSource) = setup();
+      final (yumemiWeatherService, weatherDataSource) = providerSetup();
 
       when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.invalidParameter);
@@ -124,7 +124,7 @@ void main() {
         'with message of "Failed to load data" '
         'when YumemiWeatherError.unknown is thrown.', () {
       // Arrange
-      final (yumemiWeatherService, weatherDataSource) = setup();
+      final (yumemiWeatherService, weatherDataSource) = providerSetup();
 
       when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.unknown);

--- a/test/weather/weather_data_source_test.dart
+++ b/test/weather/weather_data_source_test.dart
@@ -85,7 +85,7 @@ void main() {
         'Throws YumemiWeatherException '
         'with message of "Input parameters are wrong." '
         'when YumemiWeatherError.invalidParameter is thrown.', () {
-      when(yumemiWeatherService.fetchWeather(payload))
+      when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.invalidParameter);
 
       expect(
@@ -104,7 +104,7 @@ void main() {
         'Throws YumemiWeatherException '
         'with message of "Failed to load data" '
         'when YumemiWeatherError.unknown is thrown.', () {
-      when(yumemiWeatherService.fetchWeather(payload))
+      when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.unknown);
       expect(
         () => weatherDataSource.fetchWeather(payload),

--- a/test/weather/weather_data_source_test.dart
+++ b/test/weather/weather_data_source_test.dart
@@ -45,7 +45,7 @@ void main() {
           'date': '2024-04-24T12:09:46+09:00',
         },
       );
-      when(yumemiWeatherService.fetchWeather(payload))
+      when(yumemiWeatherService.syncFetchWeather(payload))
           .thenAnswer((_) => response);
       final weatherString = weatherDataSource.fetchWeather(payload);
       expect(weatherString, response);
@@ -59,7 +59,7 @@ void main() {
           'date': '2024-04-24T12:09:46+09:00',
         },
       );
-      when(yumemiWeatherService.fetchWeather(payload))
+      when(yumemiWeatherService.syncFetchWeather(payload))
           .thenAnswer((_) => response);
       final weatherString = weatherDataSource.fetchWeather(payload);
       expect(weatherString, response);
@@ -73,7 +73,7 @@ void main() {
           'date': '2024-04-24T12:09:46+09:00',
         },
       );
-      when(yumemiWeatherService.fetchWeather(payload))
+      when(yumemiWeatherService.syncFetchWeather(payload))
           .thenAnswer((_) => response);
       final weatherString = weatherDataSource.fetchWeather(payload);
       expect(weatherString, response);

--- a/test/weather/weather_data_source_test.dart
+++ b/test/weather/weather_data_source_test.dart
@@ -13,21 +13,6 @@ import 'weather_data_source_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<YumemiWeather>()])
 void main() {
-  late YumemiWeather yumemiWeatherService;
-  late ProviderContainer container;
-  late WeatherDataSource weatherDataSource;
-
-  setUp(() {
-    yumemiWeatherService = MockYumemiWeather();
-    container = ProviderContainer(
-      overrides: [
-        yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
-      ],
-    );
-    addTearDown(container.dispose);
-    weatherDataSource = container.read(weatherDataSourceProvider);
-  });
-
   final payload = json.encode(
     {
       'area': 'tokyo',
@@ -36,7 +21,16 @@ void main() {
   );
 
   group('weatherDataSourceの正常系テスト', () {
-    test('When YumemiWeatherService returns sunny.', () {
+    test('When YumemiWeatherService returns sunny.', () async {
+      // Arrange
+      final yumemiWeatherService = MockYumemiWeather();
+      final container = ProviderContainer(
+        overrides: [
+          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherDataSource = container.read(weatherDataSourceProvider);
       final response = json.encode(
         {
           'weather_condition': 'sunny',
@@ -45,12 +39,24 @@ void main() {
           'date': '2024-04-24T12:09:46+09:00',
         },
       );
-      when(yumemiWeatherService.syncFetchWeather(payload))
-          .thenAnswer((_) => response);
-      final weatherString = weatherDataSource.fetchWeather(payload);
+      when(yumemiWeatherService.syncFetchWeather(payload)).thenReturn(response);
+
+      // Act
+      final weatherString = await weatherDataSource.fetchWeather(payload);
+
+      // Assert
       expect(weatherString, response);
     });
-    test('When YumemiWeatherService returns cloudy.', () {
+    test('When YumemiWeatherService returns cloudy.', () async {
+      // Arrange
+      final yumemiWeatherService = MockYumemiWeather();
+      final container = ProviderContainer(
+        overrides: [
+          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherDataSource = container.read(weatherDataSourceProvider);
       final response = json.encode(
         {
           'weather_condition': 'cloudy',
@@ -60,11 +66,24 @@ void main() {
         },
       );
       when(yumemiWeatherService.syncFetchWeather(payload))
-          .thenAnswer((_) => response);
-      final weatherString = weatherDataSource.fetchWeather(payload);
+          .thenReturn(response);
+
+      // Act
+      final weatherString = await weatherDataSource.fetchWeather(payload);
+
+      // Assert
       expect(weatherString, response);
     });
-    test('When YumemiWeatherService returns rainy.', () {
+    test('When YumemiWeatherService returns rainy.', () async {
+      // Arrange
+      final yumemiWeatherService = MockYumemiWeather();
+      final container = ProviderContainer(
+        overrides: [
+          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherDataSource = container.read(weatherDataSourceProvider);
       final response = json.encode(
         {
           'weather_condition': 'rainy',
@@ -74,8 +93,12 @@ void main() {
         },
       );
       when(yumemiWeatherService.syncFetchWeather(payload))
-          .thenAnswer((_) => response);
-      final weatherString = weatherDataSource.fetchWeather(payload);
+          .thenReturn(response);
+
+      // Act
+      final weatherString = await weatherDataSource.fetchWeather(payload);
+
+      // Assert
       expect(weatherString, response);
     });
   });
@@ -85,11 +108,21 @@ void main() {
         'Throws YumemiWeatherException '
         'with message of "Input parameters are wrong." '
         'when YumemiWeatherError.invalidParameter is thrown.', () {
+      // Arrange
+      final yumemiWeatherService = MockYumemiWeather();
+      final container = ProviderContainer(
+        overrides: [
+          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherDataSource = container.read(weatherDataSourceProvider);
       when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.invalidParameter);
 
+      // Act & Assert
       expect(
-        () => weatherDataSource.fetchWeather(payload),
+        () async => weatherDataSource.fetchWeather(payload),
         throwsA(
           predicate(
             (e) =>
@@ -104,10 +137,21 @@ void main() {
         'Throws YumemiWeatherException '
         'with message of "Failed to load data" '
         'when YumemiWeatherError.unknown is thrown.', () {
+      // Arrange
+      final yumemiWeatherService = MockYumemiWeather();
+      final container = ProviderContainer(
+        overrides: [
+          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherDataSource = container.read(weatherDataSourceProvider);
       when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.unknown);
+
+      // Act & Assert
       expect(
-        () => weatherDataSource.fetchWeather(payload),
+        () async => weatherDataSource.fetchWeather(payload),
         throwsA(
           predicate(
             (e) =>

--- a/test/weather/weather_data_source_test.dart
+++ b/test/weather/weather_data_source_test.dart
@@ -11,6 +11,18 @@ import 'package:yumemi_weather/yumemi_weather.dart';
 
 import 'weather_data_source_test.mocks.dart';
 
+(MockYumemiWeather, WeatherDataSource) setup() {
+  final yumemiWeatherService = MockYumemiWeather();
+  final container = ProviderContainer(
+    overrides: [
+      yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
+    ],
+  );
+  addTearDown(container.dispose);
+  final weatherDataSource = container.read(weatherDataSourceProvider);
+  return (yumemiWeatherService, weatherDataSource);
+}
+
 @GenerateNiceMocks([MockSpec<YumemiWeather>()])
 void main() {
   final payload = json.encode(
@@ -23,14 +35,8 @@ void main() {
   group('weatherDataSourceの正常系テスト', () {
     test('When YumemiWeatherService returns sunny.', () async {
       // Arrange
-      final yumemiWeatherService = MockYumemiWeather();
-      final container = ProviderContainer(
-        overrides: [
-          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherDataSource = container.read(weatherDataSourceProvider);
+      final (yumemiWeatherService, weatherDataSource) = setup();
+
       final response = json.encode(
         {
           'weather_condition': 'sunny',
@@ -49,14 +55,8 @@ void main() {
     });
     test('When YumemiWeatherService returns cloudy.', () async {
       // Arrange
-      final yumemiWeatherService = MockYumemiWeather();
-      final container = ProviderContainer(
-        overrides: [
-          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherDataSource = container.read(weatherDataSourceProvider);
+      final (yumemiWeatherService, weatherDataSource) = setup();
+
       final response = json.encode(
         {
           'weather_condition': 'cloudy',
@@ -65,8 +65,7 @@ void main() {
           'date': '2024-04-24T12:09:46+09:00',
         },
       );
-      when(yumemiWeatherService.syncFetchWeather(payload))
-          .thenReturn(response);
+      when(yumemiWeatherService.syncFetchWeather(payload)).thenReturn(response);
 
       // Act
       final weatherString = await weatherDataSource.fetchWeather(payload);
@@ -76,14 +75,8 @@ void main() {
     });
     test('When YumemiWeatherService returns rainy.', () async {
       // Arrange
-      final yumemiWeatherService = MockYumemiWeather();
-      final container = ProviderContainer(
-        overrides: [
-          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherDataSource = container.read(weatherDataSourceProvider);
+      final (yumemiWeatherService, weatherDataSource) = setup();
+
       final response = json.encode(
         {
           'weather_condition': 'rainy',
@@ -92,8 +85,7 @@ void main() {
           'date': '2024-04-24T12:09:46+09:00',
         },
       );
-      when(yumemiWeatherService.syncFetchWeather(payload))
-          .thenReturn(response);
+      when(yumemiWeatherService.syncFetchWeather(payload)).thenReturn(response);
 
       // Act
       final weatherString = await weatherDataSource.fetchWeather(payload);
@@ -109,14 +101,8 @@ void main() {
         'with message of "Input parameters are wrong." '
         'when YumemiWeatherError.invalidParameter is thrown.', () {
       // Arrange
-      final yumemiWeatherService = MockYumemiWeather();
-      final container = ProviderContainer(
-        overrides: [
-          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherDataSource = container.read(weatherDataSourceProvider);
+      final (yumemiWeatherService, weatherDataSource) = setup();
+
       when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.invalidParameter);
 
@@ -138,14 +124,8 @@ void main() {
         'with message of "Failed to load data" '
         'when YumemiWeatherError.unknown is thrown.', () {
       // Arrange
-      final yumemiWeatherService = MockYumemiWeather();
-      final container = ProviderContainer(
-        overrides: [
-          yumemiWeatherServiceProvider.overrideWithValue(yumemiWeatherService),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherDataSource = container.read(weatherDataSourceProvider);
+      final (yumemiWeatherService, weatherDataSource) = setup();
+
       when(yumemiWeatherService.syncFetchWeather(payload))
           .thenThrow(YumemiWeatherError.unknown);
 

--- a/test/weather/weather_page_test.dart
+++ b/test/weather/weather_page_test.dart
@@ -72,7 +72,14 @@ void main() {
 
       when(weatherRepository.fetchWeather(any)).thenReturn(sampleWeatherData);
       await tester.tap(find.text('reload'));
-      await tester.pump();
+      await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is CircularProgressIndicator,
+        ),
+        findsOneWidget,
+      );
+      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
 
       expect(findWithAssetName('assets/sunny.svg'), findsOneWidget);
       expect(find.text('26 ℃'), findsWidgets);
@@ -114,6 +121,14 @@ void main() {
       when(weatherRepository.fetchWeather(any)).thenReturn(sampleWeatherData);
       await tester.tap(find.text('reload'));
       await tester.pump();
+      await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is CircularProgressIndicator,
+        ),
+        findsOneWidget,
+      );
+      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
 
       expect(findWithAssetName('assets/cloudy.svg'), findsOneWidget);
       expect(find.text('20 ℃'), findsWidgets);
@@ -154,7 +169,14 @@ void main() {
 
       when(weatherRepository.fetchWeather(any)).thenReturn(sampleWeatherData);
       await tester.tap(find.text('reload'));
-      await tester.pump();
+      await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is CircularProgressIndicator,
+        ),
+        findsOneWidget,
+      );
+      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
 
       expect(findWithAssetName('assets/rainy.svg'), findsOneWidget);
       expect(find.text('16 ℃'), findsWidgets);
@@ -193,7 +215,15 @@ void main() {
           .thenThrow(const YumemiWeatherException(YumemiWeatherError.unknown));
 
       await tester.tap(find.text('reload'));
-      await tester.pump();
+      await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is CircularProgressIndicator,
+        ),
+        findsOneWidget,
+      );
+      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
+
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(
         find.text('YumemiWeatherException: Failed to load data'),
@@ -224,7 +254,14 @@ void main() {
       );
 
       await tester.tap(find.text('reload'));
-      await tester.pump();
+      await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is CircularProgressIndicator,
+        ),
+        findsOneWidget,
+      );
+      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(
         find.text('YumemiWeatherException: Input parameters are wrong.'),
@@ -256,6 +293,13 @@ void main() {
 
       await tester.tap(find.text('reload'));
       await tester.pump();
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is CircularProgressIndicator,
+        ),
+        findsOneWidget,
+      );
+      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
       expect(find.byType(AlertDialog), findsOneWidget);
     });
   });

--- a/test/weather/weather_page_test.dart
+++ b/test/weather/weather_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -23,6 +25,7 @@ Finder findWithAssetName(String assetName) => find.byWidgetPredicate(
 void main() {
   group('weatherPageの正常系テスト', () {
     testWidgets('初期状態', (tester) async {
+      // Arrange
       TestWidgetsFlutterBinding.ensureInitialized();
       await tester.binding.setSurfaceSize(const Size(430, 932));
       await tester.pumpWidget(
@@ -38,6 +41,7 @@ void main() {
         ),
       );
 
+      // Assert
       expect(find.text('close'), findsOneWidget);
       expect(find.text('reload'), findsOneWidget);
       expect(find.text('** ℃'), findsWidgets);
@@ -47,9 +51,11 @@ void main() {
       );
     });
     testWidgets('「Reload」ボタンを押したとき、天気予報画面に晴れの画像が表示される', (tester) async {
+      // Arrange
       TestWidgetsFlutterBinding.ensureInitialized();
       await tester.binding.setSurfaceSize(const Size(430, 932));
       final weatherRepository = MockWeatherRepository();
+      final fetchWeatherDataCompleter = Completer<WeatherData>();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -62,25 +68,28 @@ void main() {
           ),
         ),
       );
-
       final sampleWeatherData = WeatherData(
         weatherCondition: WeatherCondition.sunny,
         maxTemperature: 26,
         minTemperature: -20,
         date: DateTime(2024, 4, 24, 16, 46, 08),
       );
+      when(weatherRepository.fetchWeather(any))
+          .thenAnswer((_) async => fetchWeatherDataCompleter.future);
 
-      when(weatherRepository.fetchWeather(any)).thenReturn(sampleWeatherData);
+      // Act
       await tester.tap(find.text('reload'));
       await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+
+      // Assert
       expect(
         find.byWidgetPredicate(
           (widget) => widget is CircularProgressIndicator,
         ),
         findsOneWidget,
       );
-      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
-
+      fetchWeatherDataCompleter.complete(sampleWeatherData);
+      await tester.pump(); // ここで読み込みが終わるまで早送り。
       expect(findWithAssetName('assets/sunny.svg'), findsOneWidget);
       expect(find.text('26 ℃'), findsWidgets);
       expect(
@@ -95,9 +104,11 @@ void main() {
     });
 
     testWidgets('「Reload」ボタンを押したとき天気予報画面に曇りの画像が表示される', (tester) async {
+      // Arrange
       TestWidgetsFlutterBinding.ensureInitialized();
       await tester.binding.setSurfaceSize(const Size(430, 932));
       final weatherRepository = MockWeatherRepository();
+      final fetchWeatherDataCompleter = Completer<WeatherData>();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -110,25 +121,28 @@ void main() {
           ),
         ),
       );
-
       final sampleWeatherData = WeatherData(
         weatherCondition: WeatherCondition.cloudy,
         maxTemperature: 20,
         minTemperature: -20,
         date: DateTime(2024, 4, 24, 16, 46, 08),
       );
+      when(weatherRepository.fetchWeather(any))
+          .thenAnswer((_) async => fetchWeatherDataCompleter.future);
 
-      when(weatherRepository.fetchWeather(any)).thenReturn(sampleWeatherData);
+      // Act
       await tester.tap(find.text('reload'));
-      await tester.pump();
       await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+
+      // Assert
       expect(
         find.byWidgetPredicate(
           (widget) => widget is CircularProgressIndicator,
         ),
         findsOneWidget,
       );
-      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
+      fetchWeatherDataCompleter.complete(sampleWeatherData);
+      await tester.pump(); // ここで読み込みが終わるまで早送り。
 
       expect(findWithAssetName('assets/cloudy.svg'), findsOneWidget);
       expect(find.text('20 ℃'), findsWidgets);
@@ -144,9 +158,11 @@ void main() {
     });
 
     testWidgets('「Reload」ボタンを押したとき、天気予報画面に雨の画像が表示される', (tester) async {
+      // Arrange
       TestWidgetsFlutterBinding.ensureInitialized();
       await tester.binding.setSurfaceSize(const Size(430, 932));
       final weatherRepository = MockWeatherRepository();
+      final fetchWeatherDataCompleter = Completer<WeatherData>();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -159,24 +175,28 @@ void main() {
           ),
         ),
       );
-
       final sampleWeatherData = WeatherData(
         weatherCondition: WeatherCondition.rainy,
         maxTemperature: 16,
         minTemperature: -20,
         date: DateTime(2024, 4, 24, 16, 46, 08),
       );
+      when(weatherRepository.fetchWeather(any))
+          .thenAnswer((_) async => fetchWeatherDataCompleter.future);
 
-      when(weatherRepository.fetchWeather(any)).thenReturn(sampleWeatherData);
+      // Act
       await tester.tap(find.text('reload'));
       await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+
+      // Assert
       expect(
         find.byWidgetPredicate(
           (widget) => widget is CircularProgressIndicator,
         ),
         findsOneWidget,
       );
-      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
+      fetchWeatherDataCompleter.complete(sampleWeatherData);
+      await tester.pump(); // ここで読み込みが終わるまで早送り。
 
       expect(findWithAssetName('assets/rainy.svg'), findsOneWidget);
       expect(find.text('16 ℃'), findsWidgets);
@@ -196,9 +216,11 @@ void main() {
     testWidgets(
         '「Reload」ボタンを押し、YumemiWeatherError.unknownが発生した場合、'
         'エラー内容をAlertDialogで表示する', (tester) async {
+      // Arrange
       TestWidgetsFlutterBinding.ensureInitialized();
       await tester.binding.setSurfaceSize(const Size(430, 932));
       final weatherRepository = MockWeatherRepository();
+      final fetchWeatherDataCompleter = Completer<WeatherData>();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -212,18 +234,23 @@ void main() {
         ),
       );
       when(weatherRepository.fetchWeather(any))
-          .thenThrow(const YumemiWeatherException(YumemiWeatherError.unknown));
+          .thenAnswer((_) => fetchWeatherDataCompleter.future);
 
+      // Act
       await tester.tap(find.text('reload'));
       await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+
+      // Assert
       expect(
         find.byWidgetPredicate(
           (widget) => widget is CircularProgressIndicator,
         ),
         findsOneWidget,
       );
-      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
-
+      fetchWeatherDataCompleter.completeError(
+        const YumemiWeatherException(YumemiWeatherError.unknown),
+      );
+      await tester.pump(); // ここで読み込みが終わるまで早送り。
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(
         find.text('YumemiWeatherException: Failed to load data'),
@@ -234,9 +261,11 @@ void main() {
     testWidgets(
         '「Reload」ボタンを押し、YumemiWeatherError.invalidParameterが発生した場合、'
         'エラー内容をAlertDialogで表示する', (tester) async {
+      // Arrange
       TestWidgetsFlutterBinding.ensureInitialized();
       await tester.binding.setSurfaceSize(const Size(430, 932));
       final weatherRepository = MockWeatherRepository();
+      final fetchWeatherDataCompleter = Completer<WeatherData>();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -249,19 +278,24 @@ void main() {
           ),
         ),
       );
-      when(weatherRepository.fetchWeather(any)).thenThrow(
-        const YumemiWeatherException(YumemiWeatherError.invalidParameter),
-      );
+      when(weatherRepository.fetchWeather(any))
+          .thenAnswer((_) => fetchWeatherDataCompleter.future);
 
+      // Act
       await tester.tap(find.text('reload'));
       await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+
+      // Assert
       expect(
         find.byWidgetPredicate(
           (widget) => widget is CircularProgressIndicator,
         ),
         findsOneWidget,
       );
-      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
+      fetchWeatherDataCompleter.completeError(
+        const YumemiWeatherException(YumemiWeatherError.invalidParameter),
+      );
+      await tester.pump(); // ここで読み込みが終わるまで早送り。
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(
         find.text('YumemiWeatherException: Input parameters are wrong.'),
@@ -272,9 +306,11 @@ void main() {
     testWidgets(
         '「Reload」ボタンを押し、YumemiWeatherRepositoryExceptionが発生した場合、'
         'エラー内容をAlertDialogで表示する', (tester) async {
+      // Arrange
       TestWidgetsFlutterBinding.ensureInitialized();
       await tester.binding.setSurfaceSize(const Size(430, 932));
       final weatherRepository = MockWeatherRepository();
+      final fetchWeatherDataCompleter = Completer<WeatherData>();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -287,19 +323,24 @@ void main() {
           ),
         ),
       );
-      when(weatherRepository.fetchWeather(any)).thenThrow(
-        YumemiWeatherRepositoryException,
-      );
+      when(weatherRepository.fetchWeather(any))
+          .thenAnswer((_) => fetchWeatherDataCompleter.future);
 
+      // Act
       await tester.tap(find.text('reload'));
-      await tester.pump();
+      await tester.pump(); // ここでCircularProgressIndicatorは始まる。
+
+      // Assert
       expect(
         find.byWidgetPredicate(
           (widget) => widget is CircularProgressIndicator,
         ),
         findsOneWidget,
       );
-      await tester.pumpAndSettle(); // ここで読み込みが終わるまで早送り。
+      fetchWeatherDataCompleter.completeError(
+        YumemiWeatherRepositoryException,
+      );
+      await tester.pump(); // ここで読み込みが終わるまで早送り。
       expect(find.byType(AlertDialog), findsOneWidget);
     });
   });

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -11,7 +11,7 @@ import 'package:yumemi_weather/yumemi_weather.dart';
 
 import 'weather_page_view_model_test.mocks.dart';
 
-(MockWeatherRepository, ProviderContainer) setup() {
+(MockWeatherRepository, ProviderContainer) providerSetup() {
   final weatherRepository = MockWeatherRepository();
   final container = ProviderContainer(
     overrides: [
@@ -32,7 +32,7 @@ void main() {
   group('weatherPageViewModelの正常系テスト', () {
     test('initialize', () async {
       // Arrange
-      final (_, container) = setup();
+      final (_, container) = providerSetup();
 
       // Act
       container.listen(weatherPageViewModelProvider, (_, __) {});
@@ -43,7 +43,7 @@ void main() {
 
     test('When WeatherRepository returns WeatherCondition.sunny.', () async {
       // Arrange
-      final (weatherRepository, container) = setup();
+      final (weatherRepository, container) = providerSetup();
 
       final sampleWeatherData = WeatherData.fromJson(
         {
@@ -72,7 +72,7 @@ void main() {
 
     test('When WeatherRepository returns WeatherCondition.cloudy.', () async {
       // Arrange
-      final (weatherRepository, container) = setup();
+      final (weatherRepository, container) = providerSetup();
 
       final sampleWeatherData = WeatherData.fromJson(
         {
@@ -101,7 +101,7 @@ void main() {
 
     test('When WeatherRepository returns WeatherCondition.rainy.', () async {
       // Arrange
-      final (weatherRepository, container) = setup();
+      final (weatherRepository, container) = providerSetup();
 
       final sampleWeatherData = WeatherData.fromJson(
         {
@@ -135,7 +135,7 @@ void main() {
         'when WeatherRepository throws YumemiWeatherError.invalidParameter.',
         () async {
       // Arrange
-      final (weatherRepository, container) = setup();
+      final (weatherRepository, container) = providerSetup();
 
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenThrow(YumemiWeatherError.invalidParameter);

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -34,9 +34,6 @@ void main() {
       // Arrange
       final (_, container) = providerSetup();
 
-      // Act
-      container.listen(weatherPageViewModelProvider, (_, __) {});
-
       // Assert
       expect(await container.read(weatherPageViewModelProvider.future), null);
     });

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -41,6 +41,8 @@ void main() {
     test('When WeatherRepository returns WeatherCondition.sunny.', () async {
       // Arrange
       final (weatherRepository, container) = providerSetup();
+      final subscription =
+          container.listen(weatherPageViewModelProvider, (_, __) {});
 
       final sampleWeatherData = WeatherData.fromJson(
         {
@@ -60,7 +62,7 @@ void main() {
 
       // Assert
       expect(
-        container.read(weatherPageViewModelProvider),
+        subscription.read(),
         AsyncData<WeatherData?>(
           sampleWeatherData,
         ),
@@ -70,6 +72,8 @@ void main() {
     test('When WeatherRepository returns WeatherCondition.cloudy.', () async {
       // Arrange
       final (weatherRepository, container) = providerSetup();
+      final subscription =
+          container.listen(weatherPageViewModelProvider, (_, __) {});
 
       final sampleWeatherData = WeatherData.fromJson(
         {
@@ -89,7 +93,7 @@ void main() {
 
       // Assert
       expect(
-        container.read(weatherPageViewModelProvider),
+        subscription.read(),
         AsyncData<WeatherData?>(
           sampleWeatherData,
         ),
@@ -99,6 +103,8 @@ void main() {
     test('When WeatherRepository returns WeatherCondition.rainy.', () async {
       // Arrange
       final (weatherRepository, container) = providerSetup();
+      final subscription =
+          container.listen(weatherPageViewModelProvider, (_, __) {});
 
       final sampleWeatherData = WeatherData.fromJson(
         {
@@ -118,7 +124,7 @@ void main() {
 
       // Assert
       expect(
-        container.read(weatherPageViewModelProvider),
+        subscription.read(),
         AsyncData<WeatherData?>(
           sampleWeatherData,
         ),
@@ -133,6 +139,8 @@ void main() {
         () async {
       // Arrange
       final (weatherRepository, container) = providerSetup();
+      final subscription =
+          container.listen(weatherPageViewModelProvider, (_, __) {});
 
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenThrow(YumemiWeatherError.invalidParameter);
@@ -144,11 +152,11 @@ void main() {
 
       // Assert
       expect(
-        container.read(weatherPageViewModelProvider),
+        subscription.read(),
         isA<AsyncError<WeatherData?>>(),
       );
       expect(
-        container.read(weatherPageViewModelProvider).error,
+        subscription.read().error,
         YumemiWeatherError.invalidParameter,
       );
     });
@@ -158,13 +166,9 @@ void main() {
       'Set AsyncError(YumemiWeatherError.unknown) '
       'when WeatherRepository throws YumemiWeatherError.unknown.', () async {
     // Arrange
-    final weatherRepository = MockWeatherRepository();
-    final container = ProviderContainer(
-      overrides: [
-        weatherRepositoryProvider.overrideWithValue(weatherRepository),
-      ],
-    );
-    addTearDown(container.dispose);
+    final (weatherRepository, container) = providerSetup();
+    final subscription =
+        container.listen(weatherPageViewModelProvider, (_, __) {});
     when(weatherRepository.fetchWeather(weatherDataRequest))
         .thenThrow(YumemiWeatherError.unknown);
 
@@ -175,11 +179,11 @@ void main() {
 
     // Assert
     expect(
-      container.read(weatherPageViewModelProvider),
+      subscription.read(),
       isA<AsyncError<WeatherData?>>(),
     );
     expect(
-      container.read(weatherPageViewModelProvider).error,
+      subscription.read().error,
       YumemiWeatherError.unknown,
     );
   });
@@ -189,13 +193,9 @@ void main() {
       'when WeatherRepository throws YumemiWeatherRepositoryException.',
       () async {
     // Arrange
-    final weatherRepository = MockWeatherRepository();
-    final container = ProviderContainer(
-      overrides: [
-        weatherRepositoryProvider.overrideWithValue(weatherRepository),
-      ],
-    );
-    addTearDown(container.dispose);
+    final (weatherRepository, container) = providerSetup();
+    final subscription =
+        container.listen(weatherPageViewModelProvider, (_, __) {});
     when(weatherRepository.fetchWeather(weatherDataRequest))
         .thenThrow(YumemiWeatherRepositoryException);
 
@@ -206,11 +206,11 @@ void main() {
 
     // Assert
     expect(
-      container.read(weatherPageViewModelProvider),
+      subscription.read(),
       isA<AsyncError<WeatherData?>>(),
     );
     expect(
-      container.read(weatherPageViewModelProvider).error,
+      subscription.read().error,
       YumemiWeatherRepositoryException,
     );
   });

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -54,7 +54,7 @@ void main() {
         },
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenAnswer((realInvocation) async => sampleWeatherData);
+          .thenAnswer((_) async => sampleWeatherData);
 
       // Act
       await container
@@ -83,7 +83,7 @@ void main() {
         },
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenAnswer((realInvocation) async => sampleWeatherData);
+          .thenAnswer((_) async => sampleWeatherData);
 
       // Act
       await container
@@ -112,7 +112,7 @@ void main() {
         },
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenAnswer((realInvocation) async => sampleWeatherData);
+          .thenAnswer((_) async => sampleWeatherData);
 
       // Act
       await container

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -30,21 +30,15 @@ void main() {
   );
 
   group('weatherPageViewModelの正常系テスト', () {
-    test('initialize', () {
+    test('initialize', () async {
       // Arrange
       final (_, container) = setup();
-      
+
       // Act
-      container.listen(
-        weatherPageViewModelProvider,
-        (_, __) {
-          // Assert
-          expect(
-            container.read(weatherPageViewModelProvider),
-            const AsyncData<WeatherData?>(null),
-          );
-        },
-      );
+      container.listen(weatherPageViewModelProvider, (_, __) {});
+
+      // Assert
+      expect(await container.read(weatherPageViewModelProvider.future), null);
     });
 
     test('When WeatherRepository returns WeatherCondition.sunny.', () async {

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_training/exceptions/yumemi_weather_repository_exception_error.dart';
@@ -50,11 +52,16 @@ void main() {
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenAnswer((realInvocation) => sampleWeatherData);
-      await weatherPageViewModel.fetchWeather(weatherDataRequest);
-      expect(
-        weatherPageViewModel.state,
-        AsyncData<WeatherData?>(
-          sampleWeatherData,
+      unawaited(
+        weatherPageViewModel.fetchWeather(weatherDataRequest).then(
+          (value) {
+            expect(
+              weatherPageViewModel.state,
+              AsyncData<WeatherData?>(
+                sampleWeatherData,
+              ),
+            );
+          },
         ),
       );
     });
@@ -70,11 +77,16 @@ void main() {
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenAnswer((realInvocation) => sampleWeatherData);
-      await weatherPageViewModel.fetchWeather(weatherDataRequest);
-      expect(
-        weatherPageViewModel.state,
-        AsyncData<WeatherData?>(
-          sampleWeatherData,
+      unawaited(
+        weatherPageViewModel.fetchWeather(weatherDataRequest).then(
+          (value) {
+            expect(
+              weatherPageViewModel.state,
+              AsyncData<WeatherData?>(
+                sampleWeatherData,
+              ),
+            );
+          },
         ),
       );
     });
@@ -90,11 +102,16 @@ void main() {
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenAnswer((realInvocation) => sampleWeatherData);
-      await weatherPageViewModel.fetchWeather(weatherDataRequest);
-      expect(
-        weatherPageViewModel.state,
-        AsyncData<WeatherData?>(
-          sampleWeatherData,
+      unawaited(
+        weatherPageViewModel.fetchWeather(weatherDataRequest).then(
+          (value) {
+            expect(
+              weatherPageViewModel.state,
+              AsyncData<WeatherData?>(
+                sampleWeatherData,
+              ),
+            );
+          },
         ),
       );
     });
@@ -106,11 +123,13 @@ void main() {
         () async {
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenThrow(YumemiWeatherError.invalidParameter);
-      await weatherPageViewModel.fetchWeather(weatherDataRequest);
-      expect(weatherPageViewModel.state, isA<AsyncError<WeatherData?>>());
-      expect(
-        weatherPageViewModel.state.error,
-        YumemiWeatherError.invalidParameter,
+      unawaited(
+        weatherPageViewModel.fetchWeather(weatherDataRequest).then((value) {
+          expect(
+            weatherPageViewModel.state,
+            isA<AsyncError<YumemiWeatherError>>(),
+          );
+        }),
       );
     });
 
@@ -119,11 +138,13 @@ void main() {
         'when WeatherRepository throws YumemiWeatherError.unknown.', () async {
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenThrow(YumemiWeatherError.unknown);
-      await weatherPageViewModel.fetchWeather(weatherDataRequest);
-      expect(weatherPageViewModel.state, isA<AsyncError<WeatherData?>>());
-      expect(
-        weatherPageViewModel.state.error,
-        YumemiWeatherError.unknown,
+      unawaited(
+        weatherPageViewModel.fetchWeather(weatherDataRequest).then((value) {
+          expect(
+            weatherPageViewModel.state,
+            isA<AsyncError<YumemiWeatherError>>(),
+          );
+        }),
       );
     });
 
@@ -133,11 +154,13 @@ void main() {
         () async {
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenThrow(YumemiWeatherRepositoryException);
-      await weatherPageViewModel.fetchWeather(weatherDataRequest);
-      expect(weatherPageViewModel.state, isA<AsyncError<WeatherData?>>());
-      expect(
-        weatherPageViewModel.state.error,
-        YumemiWeatherRepositoryException,
+      unawaited(
+        weatherPageViewModel.fetchWeather(weatherDataRequest).then((value) {
+          expect(
+            weatherPageViewModel.state,
+            isA<AsyncError<YumemiWeatherRepositoryException>>(),
+          );
+        }),
       );
     });
   });

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_training/exceptions/yumemi_weather_repository_exception_error.dart';
@@ -15,22 +13,6 @@ import 'weather_page_view_model_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<WeatherRepository>()])
 void main() {
-  late WeatherRepository weatherRepository;
-  late ProviderContainer container;
-  late WeatherPageViewModel weatherPageViewModel;
-
-  setUp(() {
-    weatherRepository = MockWeatherRepository();
-    container = ProviderContainer(
-      overrides: [
-        weatherRepositoryProvider.overrideWithValue(weatherRepository),
-      ],
-    );
-    addTearDown(container.dispose);
-    weatherPageViewModel =
-        container.read(weatherPageViewModelProvider.notifier);
-  });
-
   final weatherDataRequest = WeatherDataRequest(
     area: 'tokyo',
     date: DateTime.now(),
@@ -38,10 +20,37 @@ void main() {
 
   group('weatherPageViewModelの正常系テスト', () {
     test('initialize', () {
-      expect(weatherPageViewModel.state, const AsyncData<WeatherData?>(null));
+      // Arrange
+      final weatherRepository = MockWeatherRepository();
+      final container = ProviderContainer(
+        overrides: [
+          weatherRepositoryProvider.overrideWithValue(weatherRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Act
+      container.listen(
+        weatherPageViewModelProvider,
+        (_, __) {
+          // Assert
+          expect(
+            container.read(weatherPageViewModelProvider),
+            const AsyncData<WeatherData?>(null),
+          );
+        },
+      );
     });
 
     test('When WeatherRepository returns WeatherCondition.sunny.', () async {
+      // Arrange
+      final weatherRepository = MockWeatherRepository();
+      final container = ProviderContainer(
+        overrides: [
+          weatherRepositoryProvider.overrideWithValue(weatherRepository),
+        ],
+      );
+      addTearDown(container.dispose);
       final sampleWeatherData = WeatherData.fromJson(
         {
           'weather_condition': 'sunny',
@@ -51,22 +60,31 @@ void main() {
         },
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenAnswer((realInvocation) => sampleWeatherData);
-      unawaited(
-        weatherPageViewModel.fetchWeather(weatherDataRequest).then(
-          (value) {
-            expect(
-              weatherPageViewModel.state,
-              AsyncData<WeatherData?>(
-                sampleWeatherData,
-              ),
-            );
-          },
+          .thenAnswer((realInvocation) async => sampleWeatherData);
+
+      // Act
+      await container
+          .read(weatherPageViewModelProvider.notifier)
+          .fetchWeather(weatherDataRequest);
+
+      // Assert
+      expect(
+        container.read(weatherPageViewModelProvider),
+        AsyncData<WeatherData?>(
+          sampleWeatherData,
         ),
       );
     });
 
     test('When WeatherRepository returns WeatherCondition.cloudy.', () async {
+      // Arrange
+      final weatherRepository = MockWeatherRepository();
+      final container = ProviderContainer(
+        overrides: [
+          weatherRepositoryProvider.overrideWithValue(weatherRepository),
+        ],
+      );
+      addTearDown(container.dispose);
       final sampleWeatherData = WeatherData.fromJson(
         {
           'weather_condition': 'cloudy',
@@ -76,92 +94,148 @@ void main() {
         },
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenAnswer((realInvocation) => sampleWeatherData);
-      unawaited(
-        weatherPageViewModel.fetchWeather(weatherDataRequest).then(
-          (value) {
-            expect(
-              weatherPageViewModel.state,
-              AsyncData<WeatherData?>(
-                sampleWeatherData,
-              ),
-            );
-          },
+          .thenAnswer((realInvocation) async => sampleWeatherData);
+
+      // Act
+      await container
+          .read(weatherPageViewModelProvider.notifier)
+          .fetchWeather(weatherDataRequest);
+
+      // Assert
+      expect(
+        container.read(weatherPageViewModelProvider),
+        AsyncData<WeatherData?>(
+          sampleWeatherData,
         ),
       );
     });
 
     test('When WeatherRepository returns WeatherCondition.rainy.', () async {
+      // Arrange
+      final weatherRepository = MockWeatherRepository();
+      final container = ProviderContainer(
+        overrides: [
+          weatherRepositoryProvider.overrideWithValue(weatherRepository),
+        ],
+      );
+      addTearDown(container.dispose);
       final sampleWeatherData = WeatherData.fromJson(
         {
-          'weather_condition': 'cloudy',
+          'weather_condition': 'rainy',
           'max_temperature': 26,
           'min_temperature': -20,
           'date': '2024-04-24T16:46:08+09:00',
         },
       );
       when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenAnswer((realInvocation) => sampleWeatherData);
-      unawaited(
-        weatherPageViewModel.fetchWeather(weatherDataRequest).then(
-          (value) {
-            expect(
-              weatherPageViewModel.state,
-              AsyncData<WeatherData?>(
-                sampleWeatherData,
-              ),
-            );
-          },
+          .thenAnswer((realInvocation) async => sampleWeatherData);
+
+      // Act
+      await container
+          .read(weatherPageViewModelProvider.notifier)
+          .fetchWeather(weatherDataRequest);
+
+      // Assert
+      expect(
+        container.read(weatherPageViewModelProvider),
+        AsyncData<WeatherData?>(
+          sampleWeatherData,
         ),
       );
     });
   });
+
   group('weatherPageViewModelの異常系テスト', () {
     test(
         'Set AsyncError(YumemiWeatherError.invalidParameter) '
         'when WeatherRepository throws YumemiWeatherError.invalidParameter.',
         () async {
+      // Arrange
+      final weatherRepository = MockWeatherRepository();
+      final container = ProviderContainer(
+        overrides: [
+          weatherRepositoryProvider.overrideWithValue(weatherRepository),
+        ],
+      );
+      addTearDown(container.dispose);
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenThrow(YumemiWeatherError.invalidParameter);
-      unawaited(
-        weatherPageViewModel.fetchWeather(weatherDataRequest).then((value) {
-          expect(
-            weatherPageViewModel.state,
-            isA<AsyncError<YumemiWeatherError>>(),
-          );
-        }),
-      );
-    });
 
-    test(
-        'Set AsyncError(YumemiWeatherError.unknown) '
-        'when WeatherRepository throws YumemiWeatherError.unknown.', () async {
-      when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenThrow(YumemiWeatherError.unknown);
-      unawaited(
-        weatherPageViewModel.fetchWeather(weatherDataRequest).then((value) {
-          expect(
-            weatherPageViewModel.state,
-            isA<AsyncError<YumemiWeatherError>>(),
-          );
-        }),
-      );
-    });
+      // Act
+      await container
+          .read(weatherPageViewModelProvider.notifier)
+          .fetchWeather(weatherDataRequest);
 
-    test(
-        'Set AsyncError(YumemiWeatherRepositoryException) '
-        'when WeatherRepository throws YumemiWeatherRepositoryException.',
-        () async {
-      when(weatherRepository.fetchWeather(weatherDataRequest))
-          .thenThrow(YumemiWeatherRepositoryException);
-      unawaited(
-        weatherPageViewModel.fetchWeather(weatherDataRequest).then((value) {
-          expect(
-            weatherPageViewModel.state,
-            isA<AsyncError<YumemiWeatherRepositoryException>>(),
-          );
-        }),
+      // Assert
+      expect(
+        container.read(weatherPageViewModelProvider),
+        isA<AsyncError<WeatherData?>>(),
+      );
+      expect(
+        container.read(weatherPageViewModelProvider).error,
+        YumemiWeatherError.invalidParameter,
       );
     });
+  });
+
+  test(
+      'Set AsyncError(YumemiWeatherError.unknown) '
+      'when WeatherRepository throws YumemiWeatherError.unknown.', () async {
+    // Arrange
+    final weatherRepository = MockWeatherRepository();
+    final container = ProviderContainer(
+      overrides: [
+        weatherRepositoryProvider.overrideWithValue(weatherRepository),
+      ],
+    );
+    addTearDown(container.dispose);
+    when(weatherRepository.fetchWeather(weatherDataRequest))
+        .thenThrow(YumemiWeatherError.unknown);
+
+    // Act
+    await container
+        .read(weatherPageViewModelProvider.notifier)
+        .fetchWeather(weatherDataRequest);
+
+    // Assert
+    expect(
+      container.read(weatherPageViewModelProvider),
+      isA<AsyncError<WeatherData?>>(),
+    );
+    expect(
+      container.read(weatherPageViewModelProvider).error,
+      YumemiWeatherError.unknown,
+    );
+  });
+
+  test(
+      'Set AsyncError(YumemiWeatherRepositoryException) '
+      'when WeatherRepository throws YumemiWeatherRepositoryException.',
+      () async {
+    // Arrange
+    final weatherRepository = MockWeatherRepository();
+    final container = ProviderContainer(
+      overrides: [
+        weatherRepositoryProvider.overrideWithValue(weatherRepository),
+      ],
+    );
+    addTearDown(container.dispose);
+    when(weatherRepository.fetchWeather(weatherDataRequest))
+        .thenThrow(YumemiWeatherRepositoryException);
+
+    // Act
+    await container
+        .read(weatherPageViewModelProvider.notifier)
+        .fetchWeather(weatherDataRequest);
+
+    // Assert
+    expect(
+      container.read(weatherPageViewModelProvider),
+      isA<AsyncError<WeatherData?>>(),
+    );
+    expect(
+      container.read(weatherPageViewModelProvider).error,
+      YumemiWeatherRepositoryException,
+    );
   });
 }

--- a/test/weather/weather_page_view_model_test.dart
+++ b/test/weather/weather_page_view_model_test.dart
@@ -11,6 +11,17 @@ import 'package:yumemi_weather/yumemi_weather.dart';
 
 import 'weather_page_view_model_test.mocks.dart';
 
+(MockWeatherRepository, ProviderContainer) setup() {
+  final weatherRepository = MockWeatherRepository();
+  final container = ProviderContainer(
+    overrides: [
+      weatherRepositoryProvider.overrideWithValue(weatherRepository),
+    ],
+  );
+  addTearDown(container.dispose);
+  return (weatherRepository, container);
+}
+
 @GenerateNiceMocks([MockSpec<WeatherRepository>()])
 void main() {
   final weatherDataRequest = WeatherDataRequest(
@@ -21,14 +32,8 @@ void main() {
   group('weatherPageViewModelの正常系テスト', () {
     test('initialize', () {
       // Arrange
-      final weatherRepository = MockWeatherRepository();
-      final container = ProviderContainer(
-        overrides: [
-          weatherRepositoryProvider.overrideWithValue(weatherRepository),
-        ],
-      );
-      addTearDown(container.dispose);
-
+      final (_, container) = setup();
+      
       // Act
       container.listen(
         weatherPageViewModelProvider,
@@ -44,13 +49,8 @@ void main() {
 
     test('When WeatherRepository returns WeatherCondition.sunny.', () async {
       // Arrange
-      final weatherRepository = MockWeatherRepository();
-      final container = ProviderContainer(
-        overrides: [
-          weatherRepositoryProvider.overrideWithValue(weatherRepository),
-        ],
-      );
-      addTearDown(container.dispose);
+      final (weatherRepository, container) = setup();
+
       final sampleWeatherData = WeatherData.fromJson(
         {
           'weather_condition': 'sunny',
@@ -78,13 +78,8 @@ void main() {
 
     test('When WeatherRepository returns WeatherCondition.cloudy.', () async {
       // Arrange
-      final weatherRepository = MockWeatherRepository();
-      final container = ProviderContainer(
-        overrides: [
-          weatherRepositoryProvider.overrideWithValue(weatherRepository),
-        ],
-      );
-      addTearDown(container.dispose);
+      final (weatherRepository, container) = setup();
+
       final sampleWeatherData = WeatherData.fromJson(
         {
           'weather_condition': 'cloudy',
@@ -112,13 +107,8 @@ void main() {
 
     test('When WeatherRepository returns WeatherCondition.rainy.', () async {
       // Arrange
-      final weatherRepository = MockWeatherRepository();
-      final container = ProviderContainer(
-        overrides: [
-          weatherRepositoryProvider.overrideWithValue(weatherRepository),
-        ],
-      );
-      addTearDown(container.dispose);
+      final (weatherRepository, container) = setup();
+
       final sampleWeatherData = WeatherData.fromJson(
         {
           'weather_condition': 'rainy',
@@ -151,13 +141,8 @@ void main() {
         'when WeatherRepository throws YumemiWeatherError.invalidParameter.',
         () async {
       // Arrange
-      final weatherRepository = MockWeatherRepository();
-      final container = ProviderContainer(
-        overrides: [
-          weatherRepositoryProvider.overrideWithValue(weatherRepository),
-        ],
-      );
-      addTearDown(container.dispose);
+      final (weatherRepository, container) = setup();
+
       when(weatherRepository.fetchWeather(weatherDataRequest))
           .thenThrow(YumemiWeatherError.invalidParameter);
 

--- a/test/weather/weather_page_view_model_test.mocks.dart
+++ b/test/weather/weather_page_view_model_test.mocks.dart
@@ -3,8 +3,10 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i4;
+
 import 'package:flutter_training/weather/weather_data.dart' as _i2;
-import 'package:flutter_training/weather/weather_data_request.dart' as _i4;
+import 'package:flutter_training/weather/weather_data_request.dart' as _i5;
 import 'package:flutter_training/weather/weather_repository.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
@@ -36,25 +38,27 @@ class _FakeWeatherData_0 extends _i1.SmartFake implements _i2.WeatherData {
 /// See the documentation for Mockito's code generation for more information.
 class MockWeatherRepository extends _i1.Mock implements _i3.WeatherRepository {
   @override
-  _i2.WeatherData fetchWeather(_i4.WeatherDataRequest? weatherDataRequest) =>
+  _i4.Future<_i2.WeatherData> fetchWeather(
+          _i5.WeatherDataRequest? weatherDataRequest) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchWeather,
           [weatherDataRequest],
         ),
-        returnValue: _FakeWeatherData_0(
+        returnValue: _i4.Future<_i2.WeatherData>.value(_FakeWeatherData_0(
           this,
           Invocation.method(
             #fetchWeather,
             [weatherDataRequest],
           ),
-        ),
-        returnValueForMissingStub: _FakeWeatherData_0(
+        )),
+        returnValueForMissingStub:
+            _i4.Future<_i2.WeatherData>.value(_FakeWeatherData_0(
           this,
           Invocation.method(
             #fetchWeather,
             [weatherDataRequest],
           ),
-        ),
-      ) as _i2.WeatherData);
+        )),
+      ) as _i4.Future<_i2.WeatherData>);
 }

--- a/test/weather/weather_repository_test.dart
+++ b/test/weather/weather_repository_test.dart
@@ -12,7 +12,7 @@ import 'package:mockito/mockito.dart';
 
 import 'weather_repository_test.mocks.dart';
 
-(MockWeatherDataSource, WeatherRepository) setup() {
+(MockWeatherDataSource, WeatherRepository) providerSetup() {
   final weatherDataSource = MockWeatherDataSource();
   final container = ProviderContainer(
     overrides: [
@@ -40,7 +40,7 @@ void main() {
   group('weatherRepositoryの正常系テスト', () {
     test('When WeatherDataSource returns sunny.', () async {
       // Arrange
-      final (weatherDataSource, weatherRepository) = setup();
+      final (weatherDataSource, weatherRepository) = providerSetup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (_) async => json.encode(
@@ -70,7 +70,7 @@ void main() {
 
     test('When WeatherDataSource returns cloudy.', () async {
       // Arrange
-      final (weatherDataSource, weatherRepository) = setup();
+      final (weatherDataSource, weatherRepository) = providerSetup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (_) async => json.encode(
@@ -100,7 +100,7 @@ void main() {
 
     test('When WeatherDataSource returns rainy.', () async {
       // Arrange
-      final (weatherDataSource, weatherRepository) = setup();
+      final (weatherDataSource, weatherRepository) = providerSetup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (_) async => json.encode(
@@ -135,7 +135,7 @@ void main() {
         'When WeatherDataSource returns snowy. '
         '(including invalid value)', () async {
       // Arrange
-      final (weatherDataSource, weatherRepository) = setup();
+      final (weatherDataSource, weatherRepository) = providerSetup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (_) async => json.encode(
@@ -161,7 +161,7 @@ void main() {
         'Throws YumemiWeatherRepositoryException '
         'When the data is not appropriate format.', () async {
       // Arrange
-      final (weatherDataSource, weatherRepository) = setup();
+      final (weatherDataSource, weatherRepository) = providerSetup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (_) async => json.encode(

--- a/test/weather/weather_repository_test.dart
+++ b/test/weather/weather_repository_test.dart
@@ -14,21 +14,6 @@ import 'weather_repository_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<WeatherDataSource>()])
 void main() {
-  late WeatherDataSource weatherDataSource;
-  late ProviderContainer container;
-  late WeatherRepository weatherRepository;
-
-  setUp(() {
-    weatherDataSource = MockWeatherDataSource();
-    container = ProviderContainer(
-      overrides: [
-        weatherDataSourceProvider.overrideWithValue(weatherDataSource),
-      ],
-    );
-    addTearDown(container.dispose);
-    weatherRepository = container.read(weatherRepositoryProvider);
-  });
-
   /// weatherDataSourceではjsonで入出力する形となっております。
   /// そこでweatherDataSourceとweatherRepositoryへの入力を揃えるために
   /// weatherDataRequestとweatherDataPayloadをそれぞれ一つのMapから生成しました。
@@ -41,9 +26,18 @@ void main() {
   final weatherDataPayload = json.encode(payload);
 
   group('weatherRepositoryの正常系テスト', () {
-    test('When WeatherDataSource returns sunny.', () {
+    test('When WeatherDataSource returns sunny.', () async {
+      // Arrange
+      final weatherDataSource = MockWeatherDataSource();
+      final container = ProviderContainer(
+        overrides: [
+          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherRepository = container.read(weatherRepositoryProvider);
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) => json.encode(
+        (realInvocation) async => json.encode(
           {
             'weather_condition': 'sunny',
             'max_temperature': 33,
@@ -52,7 +46,11 @@ void main() {
           },
         ),
       );
-      final weather = weatherRepository.fetchWeather(weatherDataRequest);
+
+      // Act
+      final weather = await weatherRepository.fetchWeather(weatherDataRequest);
+
+      // Assert
       expect(
         weather,
         WeatherData(
@@ -64,9 +62,18 @@ void main() {
       );
     });
 
-    test('When WeatherDataSource returns cloudy.', () {
+    test('When WeatherDataSource returns cloudy.', () async {
+      // Arrange
+      final weatherDataSource = MockWeatherDataSource();
+      final container = ProviderContainer(
+        overrides: [
+          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherRepository = container.read(weatherRepositoryProvider);
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) => json.encode(
+        (realInvocation) async => json.encode(
           {
             'weather_condition': 'cloudy',
             'max_temperature': 25,
@@ -75,7 +82,11 @@ void main() {
           },
         ),
       );
-      final weather = weatherRepository.fetchWeather(weatherDataRequest);
+
+      // Act
+      final weather = await weatherRepository.fetchWeather(weatherDataRequest);
+
+      // Assert
       expect(
         weather,
         WeatherData(
@@ -87,9 +98,18 @@ void main() {
       );
     });
 
-    test('When WeatherDataSource returns rainy.', () {
+    test('When WeatherDataSource returns rainy.', () async {
+      // Arrange
+      final weatherDataSource = MockWeatherDataSource();
+      final container = ProviderContainer(
+        overrides: [
+          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherRepository = container.read(weatherRepositoryProvider);
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) => json.encode(
+        (realInvocation) async => json.encode(
           {
             'weather_condition': 'rainy',
             'max_temperature': 25,
@@ -98,7 +118,11 @@ void main() {
           },
         ),
       );
-      final weather = weatherRepository.fetchWeather(weatherDataRequest);
+
+      // Act
+      final weather = await weatherRepository.fetchWeather(weatherDataRequest);
+
+      // Assert
       expect(
         weather,
         WeatherData(
@@ -115,9 +139,18 @@ void main() {
     test(
         'Throws YumemiWeatherRepositoryException '
         'When WeatherDataSource returns snowy. '
-        '(including invalid value)', () {
+        '(including invalid value)', () async {
+      // Arrange
+      final weatherDataSource = MockWeatherDataSource();
+      final container = ProviderContainer(
+        overrides: [
+          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherRepository = container.read(weatherRepositoryProvider);
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) => json.encode(
+        (realInvocation) async => json.encode(
           {
             'weather_condition': 'snowy',
             'max_temperature': 1,
@@ -126,8 +159,10 @@ void main() {
           },
         ),
       );
+
+      // Act & Assert
       expect(
-        () => weatherRepository.fetchWeather(weatherDataRequest),
+        () async => weatherRepository.fetchWeather(weatherDataRequest),
         throwsA(
           isA<YumemiWeatherRepositoryException>(),
         ),
@@ -136,16 +171,27 @@ void main() {
 
     test(
         'Throws YumemiWeatherRepositoryException '
-        'When the data is not appropriate format.', () {
+        'When the data is not appropriate format.', () async {
+      // Arrange
+      final weatherDataSource = MockWeatherDataSource();
+      final container = ProviderContainer(
+        overrides: [
+          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
+        ],
+      );
+      addTearDown(container.dispose);
+      final weatherRepository = container.read(weatherRepositoryProvider);
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) => json.encode(
+        (realInvocation) async => json.encode(
           {
             'weather_condition': 'rainy',
           },
         ),
       );
+
+      // Act & Assert
       expect(
-        () => weatherRepository.fetchWeather(weatherDataRequest),
+        () async => weatherRepository.fetchWeather(weatherDataRequest),
         throwsA(
           isA<YumemiWeatherRepositoryException>(),
         ),

--- a/test/weather/weather_repository_test.dart
+++ b/test/weather/weather_repository_test.dart
@@ -43,7 +43,7 @@ void main() {
       final (weatherDataSource, weatherRepository) = setup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) async => json.encode(
+        (_) async => json.encode(
           {
             'weather_condition': 'sunny',
             'max_temperature': 33,
@@ -73,7 +73,7 @@ void main() {
       final (weatherDataSource, weatherRepository) = setup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) async => json.encode(
+        (_) async => json.encode(
           {
             'weather_condition': 'cloudy',
             'max_temperature': 25,
@@ -103,7 +103,7 @@ void main() {
       final (weatherDataSource, weatherRepository) = setup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) async => json.encode(
+        (_) async => json.encode(
           {
             'weather_condition': 'rainy',
             'max_temperature': 25,
@@ -138,7 +138,7 @@ void main() {
       final (weatherDataSource, weatherRepository) = setup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) async => json.encode(
+        (_) async => json.encode(
           {
             'weather_condition': 'snowy',
             'max_temperature': 1,
@@ -164,7 +164,7 @@ void main() {
       final (weatherDataSource, weatherRepository) = setup();
       
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
-        (realInvocation) async => json.encode(
+        (_) async => json.encode(
           {
             'weather_condition': 'rainy',
           },

--- a/test/weather/weather_repository_test.dart
+++ b/test/weather/weather_repository_test.dart
@@ -12,6 +12,18 @@ import 'package:mockito/mockito.dart';
 
 import 'weather_repository_test.mocks.dart';
 
+(MockWeatherDataSource, WeatherRepository) setup() {
+  final weatherDataSource = MockWeatherDataSource();
+  final container = ProviderContainer(
+    overrides: [
+      weatherDataSourceProvider.overrideWithValue(weatherDataSource),
+    ],
+  );
+  addTearDown(container.dispose);
+  final weatherRepository = container.read(weatherRepositoryProvider);
+  return (weatherDataSource, weatherRepository);
+}
+
 @GenerateNiceMocks([MockSpec<WeatherDataSource>()])
 void main() {
   /// weatherDataSourceではjsonで入出力する形となっております。
@@ -28,14 +40,8 @@ void main() {
   group('weatherRepositoryの正常系テスト', () {
     test('When WeatherDataSource returns sunny.', () async {
       // Arrange
-      final weatherDataSource = MockWeatherDataSource();
-      final container = ProviderContainer(
-        overrides: [
-          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherRepository = container.read(weatherRepositoryProvider);
+      final (weatherDataSource, weatherRepository) = setup();
+      
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (realInvocation) async => json.encode(
           {
@@ -64,14 +70,8 @@ void main() {
 
     test('When WeatherDataSource returns cloudy.', () async {
       // Arrange
-      final weatherDataSource = MockWeatherDataSource();
-      final container = ProviderContainer(
-        overrides: [
-          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherRepository = container.read(weatherRepositoryProvider);
+      final (weatherDataSource, weatherRepository) = setup();
+      
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (realInvocation) async => json.encode(
           {
@@ -100,14 +100,8 @@ void main() {
 
     test('When WeatherDataSource returns rainy.', () async {
       // Arrange
-      final weatherDataSource = MockWeatherDataSource();
-      final container = ProviderContainer(
-        overrides: [
-          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherRepository = container.read(weatherRepositoryProvider);
+      final (weatherDataSource, weatherRepository) = setup();
+      
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (realInvocation) async => json.encode(
           {
@@ -141,14 +135,8 @@ void main() {
         'When WeatherDataSource returns snowy. '
         '(including invalid value)', () async {
       // Arrange
-      final weatherDataSource = MockWeatherDataSource();
-      final container = ProviderContainer(
-        overrides: [
-          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherRepository = container.read(weatherRepositoryProvider);
+      final (weatherDataSource, weatherRepository) = setup();
+      
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (realInvocation) async => json.encode(
           {
@@ -173,14 +161,8 @@ void main() {
         'Throws YumemiWeatherRepositoryException '
         'When the data is not appropriate format.', () async {
       // Arrange
-      final weatherDataSource = MockWeatherDataSource();
-      final container = ProviderContainer(
-        overrides: [
-          weatherDataSourceProvider.overrideWithValue(weatherDataSource),
-        ],
-      );
-      addTearDown(container.dispose);
-      final weatherRepository = container.read(weatherRepositoryProvider);
+      final (weatherDataSource, weatherRepository) = setup();
+      
       when(weatherDataSource.fetchWeather(weatherDataPayload)).thenAnswer(
         (realInvocation) async => json.encode(
           {

--- a/test/weather/weather_repository_test.mocks.dart
+++ b/test/weather/weather_repository_test.mocks.dart
@@ -3,9 +3,11 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i3;
+
 import 'package:flutter_training/weather/weather_data_source.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i3;
+import 'package:mockito/src/dummies.dart' as _i4;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -25,24 +27,25 @@ import 'package:mockito/src/dummies.dart' as _i3;
 /// See the documentation for Mockito's code generation for more information.
 class MockWeatherDataSource extends _i1.Mock implements _i2.WeatherDataSource {
   @override
-  String fetchWeather(String? payload) => (super.noSuchMethod(
+  _i3.Future<String> fetchWeather(String? payload) => (super.noSuchMethod(
         Invocation.method(
           #fetchWeather,
           [payload],
         ),
-        returnValue: _i3.dummyValue<String>(
+        returnValue: _i3.Future<String>.value(_i4.dummyValue<String>(
           this,
           Invocation.method(
             #fetchWeather,
             [payload],
           ),
-        ),
-        returnValueForMissingStub: _i3.dummyValue<String>(
+        )),
+        returnValueForMissingStub:
+            _i3.Future<String>.value(_i4.dummyValue<String>(
           this,
           Invocation.method(
             #fetchWeather,
             [payload],
           ),
-        ),
-      ) as String);
+        )),
+      ) as _i3.Future<String>);
 }


### PR DESCRIPTION
## 課題

close #12

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を fetchWeather() から syncFetchWeather() に変更する
    - [✨ FetchWeatherをsyncFetchWeatherに](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/4c9b03c28ddc8423cb8e99133f1c2c10dc709525)
    - [✨ Reload直後にAsyncLoading状態をとるように](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/66b95760c16b12308beabd47d2e28ed825973ee4)
    - [🐛 YumemiWeather.syncFetchWeatherをcomputeでラップするように](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/4867b2c612ac63a5d7e9bbc32eab5a8dabca109b)
- [x] API の処理が戻るまで [CircularProgressIndicator](https://api.flutter.dev/flutter/material/CircularProgressIndicator-class.html) を表示する 
    - [✨ 待機中に CircularProgressIndicator()を表示できるように](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/23f54e08b548ef6e7c1b6e808f0e99dc02768387)
- [x] テストも非同期処理に対応するように書き換えました。
    -  [🐛 WeatherDataSourceのテストを非同期処理に書き換え](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/399c94a5ce7e24ae5f1e58d083f744aa1342f300)
    - [🐛 WeatherRepositoryのテストを非同期処理に対応するよう書き換え](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/d63c70a2a19d0f190856b4a5f2e96d6801b8ce80)
    - [🐛 WeaherPageViewModelのテストを非同期処理に対応するよう書き換え](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/d89a271664464535524f35cf61e3c2242257a777)
    - [🐛 WeatherPageのテストを非同期処理に対応するよう書き換え](https://github.com/Aosanori/yumemi-flutter-training/pull/23/commits/93818bff86dc78c2a53347c18f1a40716de98266)
## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
|![demo]|![タイトルなし](https://github.com/Aosanori/yumemi-flutter-training/assets/60128781/bddbc626-c388-49d0-aeb9-6d4976a71ed2)|

[demo]: https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/thread_block/demo.gif?raw=true